### PR TITLE
[.travis.yml] use node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 cache: yarn
 language: node_js
 node_js:
-  - "stable"
+  - "8"
 before_script:
   - npm run lint
   - npm run build


### PR DESCRIPTION
PR builds are breaking since travis using Node v10.