### PR TITLE
Commonjs no css require

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,7 +19,6 @@
           {
             "generateScopedName": "[name].[local]",
             "prepend": [ "./postcss.config.js" ],
-            "keepImport": true,
             "extractCss": {
               "dir": "./dist/",
               "relativeRoot": "./src/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material-react-components",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-react-components",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "description": "A collection of React components that implement Google's material design specification.",
   "main": "dist/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
Since the ES5 version is actually pretty useful for server-side rendering, I want it to be friendly to Node-based environments. That being said, requiring css files breaks node. So, let's take 'em out.

Individual CSS files are still included in the `dist` folder. Consumers in ES5 environments can decide themselves how to make use of them.

Example (dist/AppBar/AppBar.js):

Before:

```js
require("./AppBar.css");

var Styles = {
  "root": "AppBar-root",
  "header": "AppBar-header",
  ...
};
```

After:

```js
// no require statement

var Styles = {
  "root": "AppBar-root",
  "header": "AppBar-header",
  ...
};
```